### PR TITLE
track search no longer requires auth

### DIFF
--- a/backend/routers/spotify.py
+++ b/backend/routers/spotify.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field
 from typing import List
-from backend.util.auth_middleware import get_current_user
+from backend.util.auth_middleware import get_optional_user
 from backend.client.spotify import get_spotify_client, SpotifyClient
 
 router = APIRouter()
@@ -26,7 +26,7 @@ class TrackDetails(BaseModel):
     uri: str
 
 @router.get("/search", response_model=List[TrackDetails])
-def search_tracks(query: str, user_info: dict = Depends(get_current_user), spotify_client: SpotifyClient = Depends(get_spotify_client)):
+def search_tracks(query: str, user_info: dict | None = Depends(get_optional_user), spotify_client: SpotifyClient = Depends(get_spotify_client)):
     """Search for tracks using service account credentials"""
     try:
         results = spotify_client.search_tracks(query)
@@ -36,7 +36,7 @@ def search_tracks(query: str, user_info: dict = Depends(get_current_user), spoti
         raise HTTPException(status_code=500, detail=f"Failed to search tracks: {str(e)}")
 
 @router.get("/track/{track_id}", response_model=TrackDetails)
-def get_track(track_id: str, user_info: dict = Depends(get_current_user), spotify_client: SpotifyClient = Depends(get_spotify_client)):
+def get_track(track_id: str, user_info: dict | None = Depends(get_optional_user), spotify_client: SpotifyClient = Depends(get_spotify_client)):
     """Get track details using service account credentials"""
     try:
         track = spotify_client.get_track(track_id)

--- a/backend/tests/test_spotify_api.py
+++ b/backend/tests/test_spotify_api.py
@@ -61,4 +61,27 @@ def test_get_track_not_found(client):
     test_client, token, _ = client
     resp = test_client.get("/api/spotify/track/doesnotexist", headers={"x-stack-access-token": token})
     assert resp.status_code == 500
-    assert "Failed to fetch track" in resp.text 
+    assert "Failed to fetch track" in resp.text
+
+def test_search_tracks_without_auth(client):
+    test_client, _, mock_spotify = client
+    resp = test_client.get("/api/spotify/search?query=Mock")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    # Should match at least one track with 'Mock' in the name
+    found = False
+    for t in data:
+        if "Mock" in t["name"]:
+            found = True
+        assert_track_details(t)
+    assert found
+
+def test_get_track_without_auth(client):
+    test_client, _, mock_spotify = client
+    track_id = mock_spotify.tracks[0].id
+    resp = test_client.get(f"/api/spotify/track/{track_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == track_id
+    assert_track_details(data) 


### PR DESCRIPTION
Necessary because otherwise unauthenticated mixtape creation wouldn't work (would force user to log in as soon as they searched for a track)