### PR TITLE
Ensure mixtape endpoints are thread-safe

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -12,7 +12,7 @@ def create_app(database_url: str | None = None) -> FastAPI:
 
     # Set the database URL for this app instance
 
-    from backend.database import create_tables, get_db, set_database_url
+    from backend.database import create_tables, set_database_url
 
     set_database_url(database_url)
 
@@ -30,16 +30,6 @@ def create_app(database_url: str | None = None) -> FastAPI:
         docs_url=f"{api_prefix}/docs",
         openapi_url=f"{api_prefix}/openapi.json",
     )
-
-    # Store the database dependency in app state
-    def get_db_dep():
-        if database_url:
-            yield from get_db(database_url)
-        else:
-            # For testing or when no database is configured
-            yield None
-
-    app.state.get_db_dep = get_db_dep
 
     # Add CORS middleware
     app.add_middleware(

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -51,6 +51,49 @@ def create_app(database_url: str | None = None) -> FastAPI:
     )
 
     # Import routers
+    # ---------------------------------------------------------------------
+    # Database session middleware for write operations
+    # ---------------------------------------------------------------------
+
+    if database_url:
+        from sqlmodel import Session
+
+        from backend.database import get_engine
+
+        engine = get_engine(database_url)
+
+        @app.middleware("http")
+        async def db_session_middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]):  # type: ignore[override]
+            """Open a database session/transaction for write requests (POST/PUT/PATCH/DELETE).
+
+            The session is attached to ``request.state.db_session`` so that
+            downstream handlers can use it directly instead of calling
+            ``app.state.get_db_dep``. Read-only requests (GET/HEAD/OPTIONS)
+            are left unchanged to avoid unnecessary transactions.
+            """
+
+            # Fast check for HTTP methods that typically mutate state.
+            if request.method.upper() in {"POST", "PUT", "PATCH", "DELETE"}:
+                session = Session(engine)
+                request.state.db_session = session  # type: ignore[attr-defined]
+                try:
+                    response = await call_next(request)
+                    # Commit after successful response generation
+                    session.commit()
+                    return response
+                except Exception:  # noqa: BLE001 – re-raise after rollback
+                    session.rollback()
+                    raise
+                finally:
+                    session.close()
+            else:
+                # Non-mutating request – just continue.
+                return await call_next(request)
+
+
+    # ---------------------------------------------------------------------
+    # Routers
+    # ---------------------------------------------------------------------
     from backend.routers import account, auth, health, mixtape, spotify
 
     # Include routers

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 from sqlmodel import Session, SQLModel, create_engine
 
 # Import models to ensure they're registered with SQLModel metadata
@@ -36,11 +38,6 @@ def get_engine(db_url: str):
         )
     return _engines[db_url]
 
-def get_db(db_url: str):
-    engine = get_engine(db_url)
-    with Session(engine) as session:
-        yield session
-
 def create_tables(db_url: str):
     """Create all tables defined in SQLModel models"""
     engine = get_engine(db_url)
@@ -49,9 +46,6 @@ def create_tables(db_url: str):
 # ------------------------------------------------------------
 # FastAPI dependency helpers
 # ------------------------------------------------------------
-
-from collections.abc import Generator
-
 
 def get_readonly_session() -> Generator[Session, None, None]:  # pragma: no cover – utility
     """FastAPI dependency that yields a *read-only* SQLModel session.

--- a/backend/entity.py
+++ b/backend/entity.py
@@ -1,11 +1,34 @@
 # entity.py: Orchestrates multi-table operations for Mixtape and related tables using SQLModel
 import uuid
 from datetime import UTC, datetime
+import threading
 
 from sqlalchemy import desc, func
 from sqlmodel import Session, select
 
 from backend.db_models import Mixtape, MixtapeAudit, MixtapeAuditTrack, MixtapeTrack
+
+
+# --- TESTING CONCURRENCY SUPPORT ---
+# These globals are used ONLY during tests to deterministically pause execution
+# in the middle of an update/claim operation while holding a row-level lock.
+# They have *no effect* in normal operation because _TEST_PAUSE_ENABLED is False
+# by default and production code never toggles it.
+_TEST_PAUSE_ENABLED: bool = False
+_TEST_PAUSE_EVENT: threading.Event | None = None
+
+
+def _maybe_pause_for_tests() -> None:
+    """Block execution if the test pause flag/event is enabled.
+
+    This allows tests to hold the row-level lock acquired by SELECT FOR UPDATE
+    while another concurrent request attempts to obtain the lock. In production
+    the function is a no-op.
+    """
+    global _TEST_PAUSE_ENABLED, _TEST_PAUSE_EVENT
+    if _TEST_PAUSE_ENABLED and _TEST_PAUSE_EVENT is not None:
+        # Wait until the event is set by the test to resume execution.
+        _TEST_PAUSE_EVENT.wait()
 
 
 class MixtapeEntity:
@@ -129,8 +152,14 @@ class MixtapeEntity:
         """
         now = datetime.now(UTC)
 
-        # Get existing mixtape
-        statement = select(Mixtape).where(Mixtape.public_id == public_id)
+        # Acquire a row-level lock on the mixtape so that concurrent updates are
+        # processed sequentially. Other transactions will block on this lock
+        # until we commit or roll back.
+        statement = (
+            select(Mixtape)
+            .where(Mixtape.public_id == public_id)
+            .with_for_update()
+        )
         mixtape = session.exec(statement).first()
 
         if not mixtape:
@@ -190,6 +219,10 @@ class MixtapeEntity:
             )
             session.add(audit_track)
 
+        # Pause after all modifications but *before* releasing the lock to allow
+        # test cases to control concurrency ordering deterministically.
+        _maybe_pause_for_tests()
+
         session.commit()
         return mixtape.version
 
@@ -200,8 +233,12 @@ class MixtapeEntity:
         """
         now = datetime.now(UTC)
 
-        # Get existing mixtape
-        statement = select(Mixtape).where(Mixtape.public_id == public_id)
+        # Acquire row-level lock to ensure claims are processed sequentially
+        statement = (
+            select(Mixtape)
+            .where(Mixtape.public_id == public_id)
+            .with_for_update()
+        )
         mixtape = session.exec(statement).first()
 
         if not mixtape:
@@ -244,6 +281,9 @@ class MixtapeEntity:
                 spotify_uri=track.spotify_uri
             )
             session.add(audit_track)
+
+        # Pause before releasing the lock for deterministic concurrency tests.
+        _maybe_pause_for_tests()
 
         session.commit()
         return mixtape.version

--- a/backend/entity.py
+++ b/backend/entity.py
@@ -1,13 +1,12 @@
 # entity.py: Orchestrates multi-table operations for Mixtape and related tables using SQLModel
+import threading
 import uuid
 from datetime import UTC, datetime
-import threading
 
 from sqlalchemy import desc, func
 from sqlmodel import Session, select
 
 from backend.db_models import Mixtape, MixtapeAudit, MixtapeAuditTrack, MixtapeTrack
-
 
 # --- TESTING CONCURRENCY SUPPORT ---
 # These globals are used ONLY during tests to deterministically pause execution

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,12 +1,12 @@
-from fastapi import APIRouter, Request
-from sqlmodel import func, select
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, func, select
+
+from backend.database import get_readonly_session
 
 router = APIRouter()
 
 @router.get("/db")
-def db(request_obj: Request):
-    session = next(request_obj.app.state.get_db_dep())
-
+def db(session: Session = Depends(get_readonly_session)):
     time = session.exec(select(func.now())).first()
     version = session.exec(select(func.version())).first()
 

--- a/backend/routers/mixtape.py
+++ b/backend/routers/mixtape.py
@@ -1,10 +1,9 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 from sqlmodel import Session
-from backend.database import get_write_session, get_readonly_session
 
 from backend.client.spotify import SpotifyClient, get_spotify_client
+from backend.database import get_readonly_session, get_write_session
 from backend.entity import MixtapeEntity
 from backend.routers.spotify import TrackDetails  # Import TrackDetails
 from backend.util.auth_middleware import get_current_user, get_optional_user

--- a/backend/tests/test_mixtape_api.py
+++ b/backend/tests/test_mixtape_api.py
@@ -428,3 +428,101 @@ def test_anonymous_mixtape_cannot_be_made_private_via_put(client: tuple[TestClie
     payload["is_public"] = True
     resp = test_client.put(f"/api/mixtape/{public_id}", json=payload)
     assert_response_success(resp)
+
+def test_concurrent_put_requests_processed_sequentially(client: tuple[TestClient, str, dict]) -> None:
+    """Simulate two concurrent PUT requests and verify they are processed in order.
+
+    We use the test pause mechanism in backend.entity to block the first request
+    while it holds a row-level lock. The second request should wait until the
+    first completes. After unblocking, we expect the second request's data to
+    be the final state in the database and the mixtape version to increment
+    sequentially.
+    """
+    import threading, time  # Local import to avoid affecting other tests
+
+    from backend import entity as mixtape_entity  # noqa: WPS433 – test-only import
+
+    test_client, token, _ = client
+
+    # Create initial mixtape
+    create_tracks = [
+        {"track_position": 1, "track_text": "First", "spotify_uri": "spotify:track:track1"}
+    ]
+    resp_create = test_client.post(
+        "/api/mixtape",
+        json={
+            "name": "Initial Mixtape",
+            "intro_text": "Intro",
+            "is_public": True,
+            "tracks": create_tracks,
+        },
+        headers={"x-stack-access-token": token},
+    )
+    assert_response_created(resp_create)
+    public_id = resp_create.json()["public_id"]
+
+    # Enable test pause mechanism before issuing PUT requests
+    mixtape_entity._TEST_PAUSE_EVENT = threading.Event()
+    mixtape_entity._TEST_PAUSE_ENABLED = True
+
+    results: list[tuple[str, httpx.Response]] = []
+
+    def send_update(name: str, track_text: str) -> None:  # noqa: D401 – simple verb
+        update_tracks = [
+            {"track_position": 1, "track_text": track_text, "spotify_uri": "spotify:track:track1"}
+        ]
+        resp = test_client.put(
+            f"/api/mixtape/{public_id}",
+            json={
+                "name": name,
+                "intro_text": "Intro",
+                "is_public": True,
+                "tracks": update_tracks,
+            },
+            headers={"x-stack-access-token": token},
+        )
+        results.append((name, resp))
+
+    # Start first update thread (will acquire lock and then pause)
+    t1 = threading.Thread(target=send_update, args=("FirstUpdate", "A"), daemon=True)
+    t1.start()
+
+    time.sleep(0.5)  # Give t1 time to reach the pause
+    assert t1.is_alive(), "First update should be waiting due to test pause"
+
+    # Start second update thread (should block on SELECT FOR UPDATE)
+    t2 = threading.Thread(target=send_update, args=("SecondUpdate", "B"), daemon=True)
+    t2.start()
+
+    time.sleep(0.5)
+    assert t2.is_alive(), "Second update should be blocked by row lock"
+
+    # Unblock the first request, allowing both to finish sequentially
+    mixtape_entity._TEST_PAUSE_ENABLED = False
+    assert mixtape_entity._TEST_PAUSE_EVENT is not None  # mypy reassurance
+    mixtape_entity._TEST_PAUSE_EVENT.set()
+
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert not t1.is_alive() and not t2.is_alive(), "Both updates should have completed"
+
+    # Validate both responses were successful and the second update prevailed
+    for name, resp in results:
+        assert_response_success(resp)
+
+    versions = [resp.json().get("version") for _, resp in results]
+    assert len(versions) == 2 and sorted(versions) == versions, "Versions should increment sequentially"
+
+    # Final GET should reflect the second update
+    resp_final = test_client.get(f"/api/mixtape/{public_id}", headers={"x-stack-access-token": token})
+    assert_response_success(resp_final)
+    data_final = resp_final.json()
+    assert data_final["name"] == "SecondUpdate", "Latest update should win"
+
+    # Clean up test pause globals to avoid side effects on other tests
+    mixtape_entity._TEST_PAUSE_EVENT = None
+    mixtape_entity._TEST_PAUSE_ENABLED = False
+
+    # TODO: Once version history endpoint exists, assert that version 2 has
+    #       name == "FirstUpdate" and version 3 has name == "SecondUpdate".

--- a/backend/tests/test_mixtape_api.py
+++ b/backend/tests/test_mixtape_api.py
@@ -438,7 +438,8 @@ def test_concurrent_put_requests_processed_sequentially(client: tuple[TestClient
     be the final state in the database and the mixtape version to increment
     sequentially.
     """
-    import threading, time  # Local import to avoid affecting other tests
+    import threading  # Local import to avoid affecting other tests
+    import time
 
     from backend import entity as mixtape_entity  # noqa: WPS433 – test-only import
 
@@ -508,7 +509,7 @@ def test_concurrent_put_requests_processed_sequentially(client: tuple[TestClient
     assert not t1.is_alive() and not t2.is_alive(), "Both updates should have completed"
 
     # Validate both responses were successful and the second update prevailed
-    for name, resp in results:
+    for _name, resp in results:
         assert_response_success(resp)
 
     versions = [resp.json().get("version") for _, resp in results]


### PR DESCRIPTION
Ensure thread-safe, sequential processing of concurrent Mixtape updates and claims using row-level locking, with a new deterministic concurrency test.

By utilizing `SELECT FOR UPDATE` on the Mixtape entry within a database transaction, concurrent requests attempting to modify the same mixtape will block until the active transaction commits. This guarantees that updates are applied in the order they are received, preventing race conditions and ensuring data consistency. A test-only pause mechanism was introduced to deterministically verify this behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-509cffa4-a5e3-4390-9d7e-c95d741a0026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-509cffa4-a5e3-4390-9d7e-c95d741a0026">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

