### PR TITLE
Switch spotify client to auth code flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=postgresql://username:password@host:port/dbname
 # Spotify API credentials (get from your Spotify Developer Dashboard)
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+# Spotify refresh token (see instructions in README.md for fetching this)
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
 
 # Next.js public URL (set to http://localhost:3000 for local dev)
 NEXT_PUBLIC_VERCEL_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ Create a `.env.local` file in the root directory with the following variables:
 # Database
 DATABASE_URL=postgresql://... (from Neon)
 
-# Spotify API
+# Spotify API (fetch these from the spotify developer dashboard)
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+# Spotify refresh token (see instructions below)
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
 
 # Next.js
 NEXT_PUBLIC_VERCEL_URL=http://localhost:3000
@@ -75,6 +77,33 @@ STACK_SECRET_SERVER_KEY=your_stack_secret_server_key
 ```
 
 > **Note:** Never commit your actual secret values. See `.env.example` for a template.
+
+#### Fetching the spotify refresh token
+Fetch a long-lived Spotify refresh token by first whitelisting an arbitrary
+localhost URL (let's say http://127.0.0.1:53682/callback) in the Spotify
+developer dashboard, then manually logging in using the system user going to
+e.g.
+```
+https://accounts.spotify.com/authorize
+  ?client_id=your_spotify_client_id
+  &response_type=code
+  &redirect_uri=http%3A%2F%2F127.0.0.1%3A53682%2Fcallback
+  &scope=playlist-modify-public%20playlist-modify-private
+  &state=xyz123
+  &show_dialog=true
+```
+performing the authentication using the system user account, copying the `code`
+from the (dead) URL that you are subsequently redirected to, and then exchanging
+it for a refresh token with e.g.:
+```
+curl -X POST "https://accounts.spotify.com/api/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "your_spotify_client_id:your_spotify_client_secret" \
+  -d "grant_type=authorization_code" \
+  -d "code=PASTE_AUTH_CODE_HERE" \
+  -d "redirect_uri=http://127.0.0.1:53682/callback"
+```
+This will return a JSON blob containing a `refresh_token`.
 
 ### 3. Install Dependencies
 

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -1,14 +1,13 @@
-import logging
 import os
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+
+from backend.middleware.db_conn.global_db_conn import initialize_engine
 
 # Import custom middleware for detailed exception logging
 from backend.middleware.error_logging import exception_logging_middleware
-from backend.middleware.db_conn.global_db_conn import initialize_engine
 from backend.routers import account, auth, health, mixtape, spotify
 
 

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -6,6 +6,8 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+# Import custom middleware for detailed exception logging
+from backend.middleware.error_logging import exception_logging_middleware
 from backend.middleware.db_conn.global_db_conn import initialize_engine
 from backend.routers import account, auth, health, mixtape, spotify
 
@@ -56,16 +58,7 @@ def create_app(database_url: str | None = None) -> FastAPI:
         print(f"Outgoing response status: {str(response.status_code)}")
         return response
 
-    @app.middleware("http")
-    async def catch_exceptions_middleware(request: Request, call_next):
-        try:
-            return await call_next(request)
-        except Exception as e:
-            print(f"Unhandled exception: {e}")
-            logging.exception("Exception caught in middleware")
-            return JSONResponse(
-                status_code=500,
-                content={"detail": "Internal server error"},
-            )
+    # Add global exception logging middleware
+    app.middleware("http")(exception_logging_middleware)
 
     return app

--- a/backend/client/spotify/real.py
+++ b/backend/client/spotify/real.py
@@ -1,9 +1,9 @@
+import base64
 import os
 import threading
 import time
 from collections import OrderedDict
 from typing import Any
-import base64
 
 import requests
 

--- a/backend/client/spotify/real.py
+++ b/backend/client/spotify/real.py
@@ -3,6 +3,7 @@ import threading
 import time
 from collections import OrderedDict
 from typing import Any
+import base64
 
 import requests
 
@@ -38,12 +39,16 @@ class SpotifyClient(AbstractSpotifyClient):
                 return self._access_token
 
             url = "https://accounts.spotify.com/api/token"
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            auth_string = f"{self.client_id}:{self.client_secret}"
+            auth_bytes = auth_string.encode("utf-8")
+            auth_b64 = str(base64.b64encode(auth_bytes), "utf-8")
+            headers = {
+                "Authorization": f"Basic {auth_b64}",
+                "Content-Type": "application/x-www-form-urlencoded"
+            }
             data = {
                 "grant_type": "refresh_token",
                 "refresh_token": self.refresh_token,
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
             }
 
             response = requests.post(url, headers=headers, data=data)

--- a/backend/client/spotify/real.py
+++ b/backend/client/spotify/real.py
@@ -1,6 +1,6 @@
-import base64
 import os
 import threading
+import time
 from collections import OrderedDict
 from typing import Any
 
@@ -17,25 +17,44 @@ class SpotifyClient(AbstractSpotifyClient):
     def __init__(self):
         self.client_id = os.environ["SPOTIFY_CLIENT_ID"]
         self.client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
+        self.refresh_token = os.environ["SPOTIFY_REFRESH_TOKEN"]
         self.track_cache_size = int(os.environ.get("SPOTIFY_TRACK_CACHE_SIZE", 500))
         self.track_cache = OrderedDict[str, SpotifyTrack]()  # track_id -> SpotifyTrack
         self._cache_lock = threading.Lock()
+        self._token_lock = threading.Lock()
+        self._access_token: str | None = None
+        self._token_expiration: float = 0.0
 
-    def get_spotify_access_token(self)->str:
-        auth_string = f"{self.client_id}:{self.client_secret}"
-        auth_bytes = auth_string.encode("utf-8")
-        auth_b64 = str(base64.b64encode(auth_bytes), "utf-8")
-        url = "https://accounts.spotify.com/api/token"
-        headers = {
-            "Authorization": f"Basic {auth_b64}",
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
-        data = {"grant_type": "client_credentials"}
-        response = requests.post(url, headers=headers, data=data)
-        if response.status_code == 200:
-            return str(response.json()["access_token"])
-        else:
-            raise Exception("Failed to get Spotify access token")
+    def get_spotify_access_token(self) -> str:
+        """
+        Obtain a Spotify access token using Authorization Code flow.
+        A long-lived refresh token (SPOTIFY_REFRESH_TOKEN) is exchanged for a short-lived
+        access token which is cached in-memory until close to expiration.
+        """
+
+        with self._token_lock:
+            # Reuse cached token if still valid (leave 60-second buffer)
+            if self._access_token and time.time() < self._token_expiration - 60:
+                return self._access_token
+
+            url = "https://accounts.spotify.com/api/token"
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            data = {
+                "grant_type": "refresh_token",
+                "refresh_token": self.refresh_token,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            }
+
+            response = requests.post(url, headers=headers, data=data)
+            if response.status_code == 200:
+                payload = response.json()
+                self._access_token = str(payload["access_token"])
+                expires_in = int(payload.get("expires_in", 3600))
+                self._token_expiration = time.time() + expires_in
+                return self._access_token
+            else:
+                raise Exception(f"Failed to refresh Spotify access token: {response.text}")
 
     def spotify_api_request(self, endpoint: str, **kwargs)->Any:
         access_token = self.get_spotify_access_token()

--- a/backend/middleware/error_logging.py
+++ b/backend/middleware/error_logging.py
@@ -1,8 +1,8 @@
 import logging
 import traceback
+
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
-
 
 # Configure basic logging at import time if the root logger has no handlers configured.
 # This is important on platforms like Vercel where the runtime might not configure logging.
@@ -13,7 +13,7 @@ if not logging.getLogger().handlers:
     )
 
 
-async def exception_logging_middleware(request: Request, call_next) -> Response:  # type: ignore
+async def exception_logging_middleware(request: Request, call_next) -> Response:
     """Middleware that logs unhandled exceptions with full traceback.
 
     The middleware catches all exceptions raised downstream, logs the full traceback, and
@@ -21,7 +21,7 @@ async def exception_logging_middleware(request: Request, call_next) -> Response:
     production (e.g. Vercel logs).
     """
     try:
-        return await call_next(request)
+        return await call_next(request) # type: ignore[no-any-return]
     except Exception as exc:  # pylint: disable=broad-except
         # Log full traceback along with request information for debugging.
         logging.error(

--- a/backend/middleware/error_logging.py
+++ b/backend/middleware/error_logging.py
@@ -1,0 +1,38 @@
+import logging
+import traceback
+from fastapi import Request, Response
+from fastapi.responses import JSONResponse
+
+
+# Configure basic logging at import time if the root logger has no handlers configured.
+# This is important on platforms like Vercel where the runtime might not configure logging.
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+async def exception_logging_middleware(request: Request, call_next) -> Response:  # type: ignore
+    """Middleware that logs unhandled exceptions with full traceback.
+
+    The middleware catches all exceptions raised downstream, logs the full traceback, and
+    returns a generic 500 response. This ensures that we never swallow errors silently in
+    production (e.g. Vercel logs).
+    """
+    try:
+        return await call_next(request)
+    except Exception as exc:  # pylint: disable=broad-except
+        # Log full traceback along with request information for debugging.
+        logging.error(
+            "Unhandled exception while processing %s %s: %s\n%s",
+            request.method,
+            request.url.path,
+            exc,
+            traceback.format_exc(),
+        )
+
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Internal server error"},
+        )


### PR DESCRIPTION
Switch Spotify client to use Authorization Code flow with refresh tokens for user-specific authorization.

This change was requested to enable user-specific authorization, moving away from the application-level access provided by the client credentials flow. It introduces a refresh token mechanism and in-memory caching of access tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6c14721-608f-4246-a274-081f5a34180f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6c14721-608f-4246-a274-081f5a34180f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

